### PR TITLE
expose error

### DIFF
--- a/internal/proto/server/user.go
+++ b/internal/proto/server/user.go
@@ -26,7 +26,7 @@ func (this UserServer) Create(ctx context.Context, in *portal_proto.CreateUserPa
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 
-		return nil, status.Errorf(codes.Unavailable, "Please try again in a few moment")
+		return nil, status.Errorf(codes.Unavailable, err.Error())
 	}
 
 	return &portal_proto.CreateUserResponse{Id: int64(id)}, nil
@@ -40,7 +40,7 @@ func (this UserServer) GetBalance(ctx context.Context, in *portal_proto.GetUserB
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 
-		return nil, status.Errorf(codes.Unavailable, "Please try again in a few moment")
+		return nil, status.Errorf(codes.Unavailable, err.Error())
 	}
 
 	return &portal_proto.GetUserBalanceResponse{Amount: int64(balance)}, nil
@@ -54,7 +54,7 @@ func (this UserServer) Login(ctx context.Context, in *portal_proto.LoginPayload)
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 
-		return nil, status.Errorf(codes.Unavailable, "Please try again in a few moment")
+		return nil, status.Errorf(codes.Unavailable, err.Error())
 	}
 
 	return &portal_proto.LoginResponse{Token: token}, nil

--- a/internal/proto/server/user_test.go
+++ b/internal/proto/server/user_test.go
@@ -38,7 +38,7 @@ func TestCreateUser(t *testing.T) {
 				Err:    errors.New("database down"),
 				Status: 503_000,
 			},
-			outputErr: errors.New("rpc error: code = Unavailable desc = Please try again in a few moment"),
+			outputErr: errors.New("rpc error: code = Unavailable desc = database down"),
 		},
 		{
 			tName:    "success",
@@ -94,7 +94,7 @@ func TestGetBalance(t *testing.T) {
 				Err:    errors.New("database down"),
 				Status: 503_000,
 			},
-			outputErr: errors.New("rpc error: code = Unavailable desc = Please try again in a few moment"),
+			outputErr: errors.New("rpc error: code = Unavailable desc = database down"),
 		},
 		{
 			tName: "success",
@@ -149,7 +149,7 @@ func TestLogin(t *testing.T) {
 				Err:    errors.New("database down"),
 				Status: 503_000,
 			},
-			outputErr: errors.New("rpc error: code = Unavailable desc = Please try again in a few moment"),
+			outputErr: errors.New("rpc error: code = Unavailable desc = database down"),
 		},
 		{
 			tName:       "success",


### PR DESCRIPTION
internal communication should expose the error
gateway to public interface should be the one who hide the error